### PR TITLE
Removed *.meta files from the ignored ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,6 @@ artifacts/
 *_p.c
 *_i.h
 *.ilk
-*.meta
 *.obj
 *.pch
 *.pdb


### PR DESCRIPTION
Those files are required by Unity to keep track of GameObject that are related to other assets, scripts et cetera.